### PR TITLE
いいね！ボタンの新しいIDに対応

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -9,7 +9,8 @@
 
   // いいねボタンがDOMに追加されるのを監視
   const observer = new MutationObserver((mutations, observerInstance) => {
-    const button = document.getElementById('hover-card::rf::trigger');
+    const button = document.getElementById('hover-card::rf::trigger') ||
+                   document.getElementById('hover-card:«rf»:trigger');
     if (button) {
       // ボタンが見つかったら監視を停止
       observerInstance.disconnect();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "permissions": ["storage"],
   "options_page": "options.html",
   "action": {


### PR DESCRIPTION
#2 の問題に対応
段階的にデプロイされているようなので、旧式のIDを使った処理も残す